### PR TITLE
xqd_multivalue: check the maximum length of each element

### DIFF
--- a/xqd_multivalue.go
+++ b/xqd_multivalue.go
@@ -22,6 +22,9 @@ func xqd_multivalue(memory *Memory, data []string, addr int32, maxlen int32, cur
 		return XqdStatusOK
 	}
 
+	if len([]byte(data[cursor]))+1 > int(maxlen) {
+		return XqdErrBufferLength
+	}
 	var v = []byte(data[cursor])
 	v = append(v, '\x00')
 


### PR DESCRIPTION
Avoid a buffer overflow if the supplied buffer is too small.

Client libraries are expected to retry with a larger buffer if an `XqdErrBufferLength` status code is returned.