### PR TITLE
Update the CLI and the example program

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ a `http.Handler` for you to use.
 There's a proxy implementation in `cmd/fastlike` which you can run with:
 
 ```
-$ go run ./cmd/fastlike -wasm <wasmfile> -proxy-to <proxy address>
+$ go run ./cmd/fastlike -wasm <wasmfile> -backend <proxy address>
 ```
 
 You don't need the fastly CLI to build the test program either, as long as you have rust installed
@@ -14,7 +14,7 @@ and the wasm32-wasi target available:
 
 ```
 $ cd testdata; cargo build; cd ..
-$ go run ./cmd/fastlike -wasm ./testdata/target/wasm32-wasi/debug/fastlike-example.wasm -proxy-to <proxy address>
+$ go run ./cmd/fastlike -wasm ./testdata/target/wasm32-wasi/debug/fastlike-example.wasm -backend <proxy address>
 ```
 
 However, the [fastly cli](https://github.com/fastly/cli) will help you get your toolchains up to
@@ -25,7 +25,7 @@ For a more full-featured example:
 ```
 # in one terminal:
 $ cd testdata; fastly compute build; cd ..
-$ go run ./cmd/fastlike -wasm ./testdata/bin/main.wasm -proxy-to localhost:8000 -bind localhost:5000
+$ go run ./cmd/fastlike -wasm ./testdata/bin/main.wasm -backend localhost:8000 -bind localhost:5000
 
 # in another
 $ python3 -m http.server

--- a/cmd/fastlike/main.go
+++ b/cmd/fastlike/main.go
@@ -14,8 +14,12 @@ import (
 
 func main() {
 	var wasm = flag.String("wasm", "", "wasm program to execute")
-	var bind = flag.String("b", "localhost:5000", "address to bind to")
-	var proxyTo = flag.String("proxy-to", "", "(required) override to send all subrequests to")
+	var bind = flag.String("bind", "localhost:5000", "address to bind to")
+
+	var backends = make(backendFlags)
+	flag.Var(&backends, "backend", "<name=address> specifying backends. Use an empty name to specify a catch-all backend (ex: -backend localhost:2000)")
+	flag.Var(&backends, "b", "alias for -backend")
+
 	flag.Parse()
 
 	if *wasm == "" {
@@ -24,24 +28,32 @@ func main() {
 		os.Exit(1)
 	}
 
-	httpbin := httputil.NewSingleHostReverseProxy(parse("http://httpbin.org"))
-	proxy := httputil.NewSingleHostReverseProxy(parse(*proxyTo))
+	if len(backends) == 0 {
+		fmt.Fprintf(flag.CommandLine.Output(), "at least one -backend is required\n")
+		flag.Usage()
+		os.Exit(1)
+	}
 
 	var opts = []fastlike.InstanceOption{}
 
-	// NOTE: You probably want to specify a proxy-to, otherwise any requests that get proxied
-	// without changing the hostname will loop and be blocked.
-	if *proxyTo != "" {
-		opts = append(opts, fastlike.BackendHandlerOption(func(be string) http.Handler {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if be == "httpbin" {
-					httpbin.ServeHTTP(w, r)
-				} else {
-					proxy.ServeHTTP(w, r)
-				}
-			})
-		}))
-	}
+	opts = append(opts, fastlike.BackendHandlerOption(func(be string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			backend, exists := backends[be]
+			if exists {
+				backend.proxy.ServeHTTP(w, r)
+				return
+			}
+
+			fallback, exists := backends[""]
+			if exists {
+				fallback.proxy.ServeHTTP(w, r)
+				return
+			}
+
+			w.WriteHeader(http.StatusBadGateway)
+			w.Write([]byte(fmt.Sprintf("Unknown backend %s.", be)))
+		})
+	}))
 
 	fl := fastlike.New(*wasm, opts...)
 
@@ -51,15 +63,44 @@ func main() {
 	}
 }
 
-func parse(u string) *url.URL {
-	if !strings.HasPrefix(u, "http") {
-		u = fmt.Sprintf("http://%s", u)
+type backend struct {
+	address string
+	proxy   http.Handler
+}
+type backendFlags map[string]backend
+
+func (f *backendFlags) String() string {
+	rv := make([]string, len(*f))
+	for name, b := range *f {
+		rv = append(rv, fmt.Sprintf("%s=%s", name, b.address))
+	}
+	return strings.Join(rv, ", ")
+}
+func (f *backendFlags) Set(v string) error {
+	parts := strings.Split(v, "=")
+	name, addr := "", ""
+	if len(parts) == 2 {
+		name = parts[0]
+		addr = parts[1]
+	} else if len(parts) == 1 {
+		name = ""
+		addr = parts[0]
+	} else {
+		return fmt.Errorf("invalid backend %s specified", v)
 	}
 
-	out, err := url.Parse(u)
+	// turn the address into an http/https url
+	if !strings.HasPrefix(addr, "http") {
+		addr = fmt.Sprintf("http://%s", addr)
+	}
+
+	dest, err := url.Parse(addr)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
-	return out
+	proxy := httputil.NewSingleHostReverseProxy(dest)
+
+	(*f)[name] = backend{address: addr, proxy: proxy}
+	return nil
 }

--- a/fastlike_test.go
+++ b/fastlike_test.go
@@ -15,7 +15,7 @@ import (
 	"fastlike.dev"
 )
 
-const wasmfile = "testdata/target/wasm32-wasi/debug/fastlike-example.wasm"
+const wasmfile = "testdata/target/wasm32-wasi/debug/example.wasm"
 
 func TestFastlike(t *testing.T) {
 	t.Parallel()

--- a/testdata/.cargo/config
+++ b/testdata/.cargo/config
@@ -1,5 +1,5 @@
 [target.wasm32-wasi]
-rustflags = ["-C", "debuginfo=2", "-C", "link-args=--export-dynamic"]
+rustflags = ["-C", "debuginfo=2"]
 
 [build]
 target = "wasm32-wasi"

--- a/testdata/Cargo.lock
+++ b/testdata/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastlike-example"
+name = "example"
 version = "0.1.0"
 dependencies = [
  "fastly 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/testdata/Cargo.lock
+++ b/testdata/Cargo.lock
@@ -4,248 +4,247 @@
 name = "anyhow"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 
 [[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bytes"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
- "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
 name = "example"
 version = "0.1.0"
 dependencies = [
- "fastly 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastly",
+ "serde_json",
 ]
 
 [[package]]
 name = "fastly"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e9d2a7ef97cb0d4619458538228ff22f527df4e8c97ba69b7a9a7375efa726"
 dependencies = [
- "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "fastly-macros 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fastly-shared 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fastly-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "bytes",
+ "chrono",
+ "fastly-macros",
+ "fastly-shared",
+ "fastly-sys",
+ "http",
+ "lazy_static",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
 name = "fastly-macros"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9984ad9326e0e677e00ab5a996942ad6eacc9b085877bc078bad9b3119fd808"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "fastly-shared"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0589ab13a2e0a54eba06e4b281b6611d10eb26fc9ab2fc59d266a6f03506f2"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "http",
+ "thiserror",
 ]
 
 [[package]]
 name = "fastly-sys"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8bb88322ba43fe939b3b18fc3e8b1387a0df67fb55c3cade44b1c4c6321589"
 dependencies = [
- "fastly-shared 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastly-shared",
 ]
 
 [[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 
 [[package]]
 name = "http"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
 ]
 
 [[package]]
 name = "num-integer"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
 ]
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "ryu"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "serde"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 dependencies = [
- "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
 version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
- "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
 name = "syn"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "thiserror"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
 dependencies = [
- "thiserror-impl 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
-"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
-"checksum fastly 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5f865c5fb31249de9b181721a02ecdc66ef39c68d7e715c65265266cdc6fe9f7"
-"checksum fastly-macros 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aa02f752373481e7f21db28482670b05c94476418614f3aef57c3c0459470b47"
-"checksum fastly-shared 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "057adc3b19851383cf03ce9020318ee6eabb8f0b187987e916417b444583f8d5"
-"checksum fastly-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6206b617d4124353ea6b2cbe3e9910409dc321f4bdb2d467fb40bc6e9eafaeec"
-"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
-"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
-"checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
-"checksum proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
-"checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
-"checksum ryu 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
-"checksum serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
-"checksum serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
-"checksum serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)" = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
-"checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
-"checksum thiserror 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
-"checksum thiserror-impl 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/testdata/Cargo.toml
+++ b/testdata/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 debug = true
 
 [dependencies]
-fastly = "^0.3.3"
-serde_json = "*"
+fastly = "^0.5.0"
+serde_json = "1.0"

--- a/testdata/Cargo.toml
+++ b/testdata/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fastlike-example"
+name = "example"
 version = "0.1.0"
 authors = []
 edition = "2018"

--- a/testdata/fastly.toml
+++ b/testdata/fastly.toml
@@ -1,6 +1,0 @@
-version = 1
-name = "fastlike-example"
-description = "An example program for the Fastlike implementation"
-authors = ["alexvidal@khanacademy.org", "infrastructure@khanacademy.org"]
-language = "rust"
-service_id = "5PjBZ4C4pQyearWZGuTxoG"

--- a/testdata/src/main.rs
+++ b/testdata/src/main.rs
@@ -3,29 +3,21 @@ use fastly::request::downstream_client_ip_addr;
 use fastly::geo::geo_lookup;
 use fastly::{Body, Error, Request, RequestExt, Response, ResponseExt};
 use fastly::uap_parse;
-use std::convert::TryFrom;
 use serde_json;
 
 const BACKEND: &str = "backend";
 
-// The example server will send any requests for this backend to httpbin.org
-const HTTPBIN: &str = "httpbin";
-
 #[fastly::main]
 fn main(mut req: Request<Body>) -> Result<impl ResponseExt, Error> {
-    if req.headers().contains_key("httpbin-proxy") {
-        return req.send(HTTPBIN)
-    }
-
     match (req.method(), req.uri().path()) {
         (&Method::GET, "/simple-response") => Ok(Response::builder()
             .status(StatusCode::OK)
-            .body(Body::try_from("Hello, world!")?)?
+            .body(Body::from("Hello, world!"))?
         ),
 
         (&Method::GET, "/no-body") => Ok(Response::builder()
             .status(StatusCode::NO_CONTENT)
-            .body(Body::new()?)?),
+            .body(Body::new())?),
 
         (&Method::GET, "/user-agent") => {
             let ua = req.headers().get("user-agent");
@@ -48,26 +40,26 @@ fn main(mut req: Request<Body>) -> Result<impl ResponseExt, Error> {
             };
             Ok(Response::builder()
                .status(StatusCode::OK)
-               .body(Body::try_from(s)?)?)
+               .body(Body::from(s))?)
         },
 
         (&Method::GET, "/append-header") => {
             req.headers_mut().insert("test-header", HeaderValue::from_static("test-value"));
-            req.send(BACKEND)
+            Ok(req.send(BACKEND)?)
         },
 
         (&Method::GET, "/append-body") => {
-            let other = Body::try_from("appended")?;
-            let rw = Response::new(Body::try_from("original\n")?);
+            let other = Body::from("appended");
+            let rw = Response::new(Body::from("original\n"));
             let (mut parts, mut body) = rw.into_parts();
-            body.append(other)?;
+            body.append(other);
             parts.status = StatusCode::OK;
             let rv = Response::from_parts(parts, body);
             Ok(rv)
         },
 
         (&Method::GET, path) if path.starts_with("/proxy") => {
-            req.send(BACKEND)
+            Ok(req.send(BACKEND)?)
         },
 
         (&Method::GET, "/panic!") => {
@@ -77,29 +69,29 @@ fn main(mut req: Request<Body>) -> Result<impl ResponseExt, Error> {
         (&Method::GET, "/geo") => {
             let ip = downstream_client_ip_addr();
             if ip.is_none() {
-                return Ok(Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR).body(Body::new()?)?);
+                return Ok(Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR).body(Body::new())?);
             }
             let geodata = geo_lookup(ip.unwrap()).unwrap();
             Ok(Response::builder()
                 .status(StatusCode::OK)
                 .body(
-                    Body::try_from(
+                    Body::from(
                         serde_json::json!({
                             "as_name": geodata.as_name(),
                         }).to_string()
-                    )?
+                    )
                 )?
             )
         },
 
         // This one is used for example purposes, not tests
         (&Method::GET, path) if path.starts_with("/testdata") => {
-            req.send(BACKEND)
+            Ok(req.send(BACKEND)?)
         },
 
         _ => Ok(Response::builder()
             .status(StatusCode::NOT_FOUND)
-            .body(Body::try_from("The page you requested could not be found")?)?
+            .body(Body::from("The page you requested could not be found"))?
         ),
     }
 }


### PR DESCRIPTION
This patch updates the CLI flags to something a bit more useful: you can specify multiple backends via the `-backend` flag (with a shorthand `-b`) by naming them. For example: `-backend httpbin=httpbin.org`. A backend without a name is used as a default if no others match.

Additionally, I updated the example wasm program to use the latest [fastly crate](https://docs.rs/fastly) and removed some unnecessary compiler flags in the default cargo overrides (as done in fastly/fastly-template-rust-default).