### PR TITLE
Setup Actions for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: Build and Test
+on:
+    push:
+        branches: [master]
+    pull_request:
+        branches: [master]
+jobs:
+    build-wasm:
+        name: Build wasm files for tests
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+            - name: Setup Rust toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: 1.47.0
+                  target: wasm32-wasi
+            - name: Build example wasm
+              working-directory: testdata
+              run: cargo build
+            - name: Upload wasm artifact
+              uses: actions/upload-artifact@v1
+              with:
+                  name: wasm-files
+                  path: testdata/target/wasm32-wasi/debug/example.wasm
+    test:
+        name: Run tests
+        runs-on: ubuntu-latest
+        needs: build-wasm
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+            - name: Setup Go toolchain
+              uses: actions/setup-go@v2
+            - name: Download wasm artifact
+              uses: actions/download-artifact@v1
+              with:
+                  name: wasm-files
+                  path: testdata/target/wasm32-wasi/debug
+            - name: Run tests
+              run: go test


### PR DESCRIPTION
Add actions for CI, which currently fails because updated to the latest `fastly` crate requires an abi method that hasn't been implemented yet.