### PR TITLE
Add xqd_req_cache_override_v2_set

### DIFF
--- a/wasmcontext.go
+++ b/wasmcontext.go
@@ -92,6 +92,7 @@ func (i *Instance) link(linker *wasmtime.Linker) {
 	linker.DefineFunc("fastly_http_req", "header_values_set", i.xqd_req_header_values_set)
 	linker.DefineFunc("fastly_http_req", "send", i.xqd_req_send)
 	linker.DefineFunc("fastly_http_req", "cache_override_set", i.xqd_req_cache_override_set)
+	linker.DefineFunc("fastly_http_req", "cache_override_v2_set", i.xqd_req_cache_override_v2_set)
 	// The Go http implementation doesn't make it easy to get at the original headers in order, so
 	// we just use the same sorted order
 	linker.DefineFunc("fastly_http_req", "original_header_names_get", i.xqd_req_header_names_get)
@@ -167,6 +168,7 @@ func (i *Instance) linklegacy(linker *wasmtime.Linker) {
 	linker.DefineFunc("env", "xqd_req_header_values_set", i.xqd_req_header_values_set)
 	linker.DefineFunc("env", "xqd_req_send", i.xqd_req_send)
 	linker.DefineFunc("env", "xqd_req_cache_override_set", i.xqd_req_cache_override_set)
+	linker.DefineFunc("env", "xqd_req_cache_override_v2_set", i.xqd_req_cache_override_v2_set)
 	// The Go http implementation doesn't make it easy to get at the original headers in order, so
 	// we just use the same sorted order
 	linker.DefineFunc("env", "xqd_req_original_header_names_get", i.xqd_req_header_names_get)

--- a/xqd_request.go
+++ b/xqd_request.go
@@ -48,6 +48,17 @@ func (i *Instance) xqd_req_cache_override_set(handle int32, tag int32, ttl int32
 	return XqdStatusOK
 }
 
+func (i *Instance) xqd_req_cache_override_v2_set(handle int32, tag int32, ttl int32, swr int32, sk int32, sk_len int32) int32 {
+	// We don't actually *do* anything with cache overrides, since we don't have or need a cache.
+
+	if i.requests.Get(int(handle)) == nil {
+		i.abilog.Printf("req_cache_override_v2_set: invalid handle %d", handle)
+		return XqdErrInvalidHandle
+	}
+
+	return XqdStatusOK
+}
+
 func (i *Instance) xqd_req_method_get(handle int32, addr int32, maxlen int32, nwritten_out int32) int32 {
 	var r = i.requests.Get(int(handle))
 	if r == nil {


### PR DESCRIPTION
This is identical to `xqd_req_cache_override_v2_set except` that it has an extra parameter for an optional surrogate key.

May fix the CI issues.