### PR TITLE
Restructure / refactor, add logging implementation

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -5,16 +5,23 @@ import (
 	"net/http"
 )
 
-// BackendHandler is a function that takes a backend name and returns an http.Handler that can
-// satisfy that backend
-type BackendHandler func(backend string) http.Handler
+func (i *Instance) addBackend(name string, h http.Handler) {
+	i.backends[name] = h
+}
 
-func defaultBackendHandler() BackendHandler {
-	return func(backend string) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusBadGateway)
-			var msg = fmt.Sprintf(`Unknown backend '%s'. Did you configure your backends correctly?`, backend)
-			w.Write([]byte(msg))
-		})
+func (i *Instance) getBackend(name string) http.Handler {
+	h, ok := i.backends[name]
+	if !ok {
+		return i.defaultBackend(name)
 	}
+
+	return h
+}
+
+func defaultBackend(name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		var msg = fmt.Sprintf(`Unknown backend '%s'. Did you configure your backends correctly?`, name)
+		w.Write([]byte(msg))
+	})
 }

--- a/constants.go
+++ b/constants.go
@@ -1,5 +1,7 @@
 package fastlike
 
+// Constants used for return values from ABI functions.
+// See https://docs.rs/fastly-shared for more.
 const (
 	XqdStatusOK           int32 = 0
 	XqdError              int32 = 1

--- a/fastlike.go
+++ b/fastlike.go
@@ -17,11 +17,11 @@ type Fastlike struct {
 	instances chan *Instance
 
 	// instancefn is called when a new instance must be created from scratch
-	instancefn func(opts ...InstanceOption) *Instance
+	instancefn func(opts ...Option) *Instance
 }
 
 // New returns a new Fastlike ready to create new instances from
-func New(wasmfile string, instanceOpts ...InstanceOption) *Fastlike {
+func New(wasmfile string, instanceOpts ...Option) *Fastlike {
 	var f = &Fastlike{}
 
 	// read in the file and store the bytes
@@ -37,7 +37,7 @@ func New(wasmfile string, instanceOpts ...InstanceOption) *Fastlike {
 	}
 
 	f.instances = make(chan *Instance, size)
-	f.instancefn = func(opts ...InstanceOption) *Instance {
+	f.instancefn = func(opts ...Option) *Instance {
 		// merge the original options with any supplied options
 		opts = append(instanceOpts, opts...)
 		return NewInstance(wasmbytes, opts...)
@@ -83,7 +83,7 @@ func (f *Fastlike) Warmup(n int) {
 // one is available, but otherwise will be constructed fresh.
 // This *must* be called for each request, as the XQD runtime is designed around a single
 // request/response pair for each instance.
-func (f *Fastlike) Instantiate(opts ...InstanceOption) *Instance {
+func (f *Fastlike) Instantiate(opts ...Option) *Instance {
 	select {
 	case i := <-f.instances:
 		for _, opt := range opts {

--- a/geo.go
+++ b/geo.go
@@ -29,7 +29,7 @@ type Geo struct {
 	UTCOffset        int     `json:"utc_offset"`
 }
 
-func DefaultGeo(ip net.IP) Geo {
+func defaultGeoLookup(ip net.IP) Geo {
 	return Geo{
 		ASName:   "fastlike",
 		ASNumber: 64496,
@@ -47,13 +47,12 @@ func DefaultGeo(ip net.IP) Geo {
 	}
 }
 
-func GeoHandler(fn func(net.IP) Geo) http.Handler {
+func geoHandler(fn func(ip net.IP) Geo) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var ip = net.ParseIP(r.Header.Get("fastly-xqd-arg1"))
-		var geo = fn(ip)
+		addr := net.ParseIP(r.Header.Get("fastly-xqd-arg1"))
+		geo := fn(addr)
 
 		w.WriteHeader(http.StatusOK)
-
 		json.NewEncoder(w).Encode(geo)
 	})
 }

--- a/handles.go
+++ b/handles.go
@@ -19,10 +19,12 @@ type RequestHandle struct {
 	hasBody bool
 }
 
+// RequestHandles is a slice of RequestHandle with functions to get and create
 type RequestHandles struct {
 	handles []*RequestHandle
 }
 
+// Get returns the RequestHandle identified by id or nil if one does not exist.
 func (rhs *RequestHandles) Get(id int) *RequestHandle {
 	if id >= len(rhs.handles) {
 		return nil
@@ -30,6 +32,8 @@ func (rhs *RequestHandles) Get(id int) *RequestHandle {
 
 	return rhs.handles[id]
 }
+
+// New creates a new RequestHandle and returns its handle id and the handle itself.
 func (rhs *RequestHandles) New() (int, *RequestHandle) {
 	rh := &RequestHandle{Request: &http.Request{}}
 	rhs.handles = append(rhs.handles, rh)
@@ -45,10 +49,12 @@ type ResponseHandle struct {
 	hasBody bool
 }
 
+// ResponseHandles is a slice of ResponseHandle with functions to get and create
 type ResponseHandles struct {
 	handles []*ResponseHandle
 }
 
+// Get returns the ResponseHandle identified by id or nil if one does not exist.
 func (rhs *ResponseHandles) Get(id int) *ResponseHandle {
 	if id >= len(rhs.handles) {
 		return nil
@@ -56,6 +62,8 @@ func (rhs *ResponseHandles) Get(id int) *ResponseHandle {
 
 	return rhs.handles[id]
 }
+
+// New creates a new ResponseHandle and returns its handle id and the handle itself.
 func (rhs *ResponseHandles) New() (int, *ResponseHandle) {
 	rh := &ResponseHandle{Response: &http.Response{StatusCode: 200}}
 	rhs.handles = append(rhs.handles, rh)
@@ -65,13 +73,19 @@ func (rhs *ResponseHandles) New() (int, *ResponseHandle) {
 // BodyHandle represents a body. It could be readable or writable, but not both.
 // For cases where it's already connected to a request or response body, the reader or writer
 // properties will reference the original request or response respectively.
-// For new bodies, `buf` will hold the contents and either the reader or writer will wrap it.
+// For new bodies, buf will hold the contents and either the reader or writer will wrap it.
 type BodyHandle struct {
+
+	// reader, writer, and closer are connected to the existing request/response body, if one exists
 	reader io.Reader
 	writer io.Writer
 	closer io.Closer
 
-	buf    *bytes.Buffer
+	// for bodies created outside of a request/response, buf holds the body content and
+	// reader/writer/closer wrap it
+	buf *bytes.Buffer
+
+	// length is the number of bytes in the body
 	length int64
 }
 
@@ -102,10 +116,12 @@ func (b *BodyHandle) Size() int64 {
 	return b.length
 }
 
+// BodyHandles is a slice of BodyHandle with methods to get and create
 type BodyHandles struct {
 	handles []*BodyHandle
 }
 
+// Get returns the BodyHandle identified by id or nil if one does not exist
 func (bhs *BodyHandles) Get(id int) *BodyHandle {
 	if id >= len(bhs.handles) {
 		return nil
@@ -123,6 +139,7 @@ func (bhs *BodyHandles) NewBuffer() (int, *BodyHandle) {
 	return len(bhs.handles) - 1, bh
 }
 
+// NewReader creates a BodyHandle whose reader and closer is connected to the supplied ReadCloser
 func (bhs *BodyHandles) NewReader(rdr io.ReadCloser) (int, *BodyHandle) {
 	bh := &BodyHandle{}
 	bh.reader = rdr
@@ -132,6 +149,7 @@ func (bhs *BodyHandles) NewReader(rdr io.ReadCloser) (int, *BodyHandle) {
 	return len(bhs.handles) - 1, bh
 }
 
+// NewWriter creates a BodyHandle whose writer is connected to the supplied Writer
 func (bhs *BodyHandles) NewWriter(w io.Writer) (int, *BodyHandle) {
 	bh := &BodyHandle{}
 	bh.writer = w

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,92 @@
+package fastlike
+
+import (
+	"bytes"
+	"io"
+	"os"
+)
+
+func (i *Instance) addLogger(name string, w io.Writer) {
+	if i.loggers == nil {
+		i.loggers = []logger{}
+	}
+
+	i.loggers = append(i.loggers, logger{name, w})
+}
+
+func (i *Instance) getLoggerHandle(name string) int {
+	for j, l := range i.loggers {
+		if l.name == name {
+			return j
+		}
+	}
+
+	// If there's no preconfigured logger by this name, create one using the default logger
+	i.addLogger(name, i.defaultLogger(name))
+	return len(i.loggers) - 1
+}
+
+func (i *Instance) getLogger(handle int) io.Writer {
+	if handle > len(i.loggers)-1 {
+		return nil
+	}
+
+	return i.loggers[handle]
+}
+
+func defaultLogger(name string) io.Writer {
+	return NewPrefixWriter(name, LineWriter{os.Stdout})
+}
+
+type logger struct {
+	name string
+	w    io.Writer
+}
+
+func (l logger) Write(data []byte) (int, error) {
+	return l.w.Write(data)
+}
+
+// LineWriter takes a writer and returns a new writer that ensures each Write call ends with
+// a newline
+type LineWriter struct{ io.Writer }
+
+// Write implements io.Writer for LineWriter
+func (lw LineWriter) Write(data []byte) (int, error) {
+	l := len(data)
+	// Ensure that all newlines in data are escaped, after stripping any trailing newlines
+	data = bytes.TrimRight(data, "\n")
+	data = bytes.ReplaceAll(data, []byte("\n"), []byte("\\n"))
+	if n, err := lw.Writer.Write(data); err != nil {
+		return n, err
+	}
+
+	if n, err := lw.Writer.Write([]byte("\n")); err != nil {
+		return n, err
+	} else {
+		// only return the length of the "original" bytes if everything goes fine
+		return l, err
+	}
+}
+
+type PrefixWriter struct {
+	io.Writer
+	prefix string
+}
+
+func (w *PrefixWriter) Write(data []byte) (n int, err error) {
+	l := len(data)
+	msg := make([]byte, len(w.prefix)+2+len(data))
+	msg = append(msg, []byte(w.prefix+": ")...)
+	msg = append(msg, data...)
+
+	if n, err := w.Writer.Write(msg); err != nil {
+		return n, err
+	}
+
+	return l, nil
+}
+
+func NewPrefixWriter(prefix string, w io.Writer) *PrefixWriter {
+	return &PrefixWriter{Writer: w, prefix: prefix}
+}

--- a/options.go
+++ b/options.go
@@ -1,40 +1,81 @@
 package fastlike
 
 import (
-	"log"
+	"io"
+	"net"
 	"net/http"
+	"os"
 )
 
-// InstanceOption is a functional option applied to an Instance when it's created
-type InstanceOption func(*Instance)
+// Option is a functional option applied to an Instance at creation time
+type Option func(*Instance)
 
-// BackendHandlerOption is an InstanceOption which configures how subrequests are issued by backend
-func BackendHandlerOption(b BackendHandler) InstanceOption {
+// WithBackend registers an `http.Handler` identified by `name` used for subrequests targeting that
+// backend
+func WithBackend(name string, h http.Handler) Option {
 	return func(i *Instance) {
-		i.backends = b
+		i.addBackend(name, h)
 	}
 }
 
-// GeoHandlerOption is an InstanceOption which controls how geographic requests are handled
-func GeoHandlerOption(b http.Handler) InstanceOption {
+// WithDefaultBackend is an Option to override the default subrequest backend.
+func WithDefaultBackend(fn func(name string) http.Handler) Option {
 	return func(i *Instance) {
-		i.geobackend = b
+		i.defaultBackend = fn
 	}
 }
 
-// LoggerConfigOption is an InstanceOption that allows configuring the loggers
-func LoggerConfigOption(fn func(logger, abilogger *log.Logger)) InstanceOption {
+// WithGeo replaces the default geographic lookup function
+func WithGeo(fn func(net.IP) Geo) Option {
 	return func(i *Instance) {
-		fn(i.log, i.abilog)
+		i.geolookup = fn
 	}
 }
 
-// SecureRequestOption is an InstanceOption that determines if a request should be considered
-// "secure" or not. If it returns true, the request url has the "https" scheme and the "fastly-ssl"
-// header set when going into the wasm program.
+// WithLogger registers a new log endpoint usable from a wasm guest
+func WithLogger(name string, w io.Writer) Option {
+	return func(i *Instance) {
+		i.addLogger(name, w)
+	}
+}
+
+// WithDefaultLogger sets the default logger used for logs issued by the guest
+// This one is different from WithLogger, because it accepts a name and returns a writer so that
+// custom implementations can print the name, if they prefer
+func WithDefaultLogger(fn func(name string) io.Writer) Option {
+	return func(i *Instance) {
+		i.defaultLogger = fn
+	}
+}
+
+// WithSecureFunc is an Option that determines if a request should be considered "secure" or not.
+// If it returns true, the request url has the "https" scheme and the "fastly-ssl" header set when
+// going into the wasm program.
 // The default implementation checks if `req.TLS` is non-nil.
-func SecureRequestOption(fn func(*http.Request) bool) InstanceOption {
+func WithSecureFunc(fn func(*http.Request) bool) Option {
 	return func(i *Instance) {
-		i.isSecure = fn
+		i.secureFn = fn
+	}
+}
+
+// WithUserAgentParser is an Option that converts user agent header values into UserAgent structs,
+// called when the guest code uses the user agent parser XQD call.
+func WithUserAgentParser(fn UserAgentParser) Option {
+	return func(i *Instance) {
+		i.uaparser = fn
+	}
+}
+
+// WithVerbosity controls how verbose the system level logs are.
+// A verbosity of 2 prints all calls from the wasm guest into the host methods
+// Currently, verbosity less than 2 does nothing
+func WithVerbosity(v int) Option {
+	return func(i *Instance) {
+		if v >= 2 {
+			i.abilog.SetOutput(os.Stderr)
+		}
+		if v >= 1 {
+			i.log.SetOutput(os.Stderr)
+		}
 	}
 }

--- a/testdata/src/main.rs
+++ b/testdata/src/main.rs
@@ -84,6 +84,14 @@ fn main(mut req: Request<Body>) -> Result<impl ResponseExt, Error> {
             )
         },
 
+        (&Method::GET, "/log") => {
+            use std::io::Write;
+            use fastly::log::Endpoint;
+            let mut endpoint = Endpoint::from_name("default");
+            writeln!(endpoint, "Hello from fastlike!").unwrap();
+            Ok(Response::builder().status(StatusCode::NO_CONTENT).body(Body::new())?)
+        },
+
         // This one is used for example purposes, not tests
         (&Method::GET, path) if path.starts_with("/testdata") => {
             Ok(req.send(BACKEND)?)

--- a/useragent.go
+++ b/useragent.go
@@ -9,11 +9,3 @@ type UserAgent struct {
 }
 
 type UserAgentParser func(uastring string) UserAgent
-
-// UserAgUserAgentParserOption is an InstanceOption that converts user agent header values into
-// UserAgent structs, called when the guest code uses the user agent parser XQD call.
-func UserAgentParserOption(fn UserAgentParser) InstanceOption {
-	return func(i *Instance) {
-		i.uaparser = fn
-	}
-}

--- a/wasmcontext.go
+++ b/wasmcontext.go
@@ -46,9 +46,6 @@ func (i *Instance) link(linker *wasmtime.Linker) {
 	// XQD Stubbing -{{{
 	// TODO: All of these XQD methods are stubbed. As they are implemented, they'll be removed from
 	// here and explicitly linked in the section below.
-	linker.DefineFunc("fastly_log", "endpoint_get", i.wasm3("endpoint_get"))
-	linker.DefineFunc("fastly_log", "write", i.wasm4("write"))
-
 	linker.DefineFunc("fastly_http_req", "pending_req_poll", i.wasm4("pending_req_poll"))
 	linker.DefineFunc("fastly_http_req", "pending_req_select", i.wasm5("pending_req_select"))
 	linker.DefineFunc("fastly_http_req", "pending_req_wait", i.wasm3("pending_req_wait"))
@@ -66,7 +63,6 @@ func (i *Instance) link(linker *wasmtime.Linker) {
 	linker.DefineFunc("fastly_http_resp", "header_insert", i.wasm5("header_insert"))
 	linker.DefineFunc("fastly_http_resp", "header_value_get", i.wasm6("header_value_get"))
 	linker.DefineFunc("fastly_http_resp", "header_remove", i.wasm3("header_remove"))
-
 	// End XQD Stubbing -}}}
 
 	// xqd.go
@@ -113,6 +109,10 @@ func (i *Instance) link(linker *wasmtime.Linker) {
 	linker.DefineFunc("fastly_http_body", "read", i.xqd_body_read)
 	linker.DefineFunc("fastly_http_body", "append", i.xqd_body_append)
 	linker.DefineFunc("fastly_http_body", "close", i.xqd_body_close)
+
+	// xqd_log.go
+	linker.DefineFunc("fastly_log", "endpoint_get", i.xqd_log_endpoint_get)
+	linker.DefineFunc("fastly_log", "write", i.xqd_log_write)
 }
 
 // linklegacy links in the abi methods using the legacy method names
@@ -120,9 +120,6 @@ func (i *Instance) linklegacy(linker *wasmtime.Linker) {
 	// XQD Stubbing -{{{
 	// TODO: All of these XQD methods are stubbed. As they are implemented, they'll be removed from
 	// here and explicitly linked in the section below.
-	linker.DefineFunc("env", "xqd_log_endpoint_get", i.wasm3("xqd_log_endpoint_get"))
-	linker.DefineFunc("env", "xqd_log_write", i.wasm4("xqd_log_write"))
-
 	linker.DefineFunc("env", "xqd_pending_req_poll", i.wasm4("xqd_pending_req_poll"))
 	linker.DefineFunc("env", "xqd_pending_req_select", i.wasm5("xqd_pending_req_select"))
 	linker.DefineFunc("env", "xqd_pending_req_wait", i.wasm3("xqd_pending_req_wait"))
@@ -141,7 +138,6 @@ func (i *Instance) linklegacy(linker *wasmtime.Linker) {
 	linker.DefineFunc("env", "xqd_resp_header_value_get", i.wasm6("xqd_resp_header_value_get"))
 
 	linker.DefineFunc("env", "xqd_body_close_downstream", i.xqd_body_close)
-
 	// End XQD Stubbing -}}}
 
 	// xqd.go
@@ -188,4 +184,8 @@ func (i *Instance) linklegacy(linker *wasmtime.Linker) {
 	linker.DefineFunc("env", "xqd_body_write", i.xqd_body_write)
 	linker.DefineFunc("env", "xqd_body_read", i.xqd_body_read)
 	linker.DefineFunc("env", "xqd_body_append", i.xqd_body_append)
+
+	// xqd_log.go
+	linker.DefineFunc("env", "xqd_log_endpoint_get", i.xqd_log_endpoint_get)
+	linker.DefineFunc("env", "xqd_log_write", i.xqd_log_write)
 }

--- a/xqd.go
+++ b/xqd.go
@@ -26,7 +26,7 @@ func (i *Instance) xqd_req_body_downstream_get(request_handle_out int32, body_ha
 	// downstream requests don't have host or scheme on the URL, but we need it
 	rh.Request.URL.Host = i.ds_request.Host
 
-	if i.isSecure(i.ds_request) {
+	if i.secureFn(i.ds_request) {
 		rh.Request.URL.Scheme = "https"
 		rh.Request.Header.Set("fastly-ssl", "1")
 	} else {

--- a/xqd_log.go
+++ b/xqd_log.go
@@ -1,0 +1,52 @@
+package fastlike
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+func (i *Instance) xqd_log_endpoint_get(name_addr int32, name_size int32, addr int32) int32 {
+	var buf = make([]byte, name_size)
+	var _, err = i.memory.ReadAt(buf, int64(name_addr))
+	if err != nil {
+		return XqdError
+	}
+
+	var name = string(buf)
+
+	i.abilog.Printf("log_endpoint_get: name=%s\n", name)
+
+	// Write an int32 "handle" to the configured log endpoint to `addr`
+	handle := i.getLoggerHandle(name)
+
+	// TODO: Should there be a way to disable the default logger to exercise errors when fetching
+	// loggers in the guest?
+
+	i.memory.PutUint32(uint32(handle), int64(addr))
+
+	return XqdStatusOK
+}
+
+func (i *Instance) xqd_log_write(handle int32, addr int32, size int32, nwritten_out int32) int32 {
+	i.abilog.Printf("log_write: handle=%d size=%d", handle, size)
+
+	var logger = i.getLogger(int(handle))
+	if logger == nil {
+		return XqdErrInvalidHandle
+	}
+
+	// Copy size bytes starting at addr into the logger
+	nwritten, err := io.CopyN(logger, bytes.NewReader(i.memory.Data()[addr:]), int64(size))
+	if err != nil {
+		fmt.Printf("got error writing to logger, err=%q\n", err)
+		// TODO: If err == EOF then there's a specific error code we can return (it means they
+		// didn't have `size` bytes in memory)
+		return XqdError
+	}
+
+	// Write out how many bytes we copied
+	i.memory.PutUint32(uint32(nwritten), int64(nwritten_out))
+
+	return XqdStatusOK
+}

--- a/xqd_request.go
+++ b/xqd_request.go
@@ -343,9 +343,9 @@ func (i *Instance) xqd_req_send(rhandle int32, bhandle int32, backend_addr, back
 	// If the backend is geolocation, we select the geobackend explicitly
 	var handler http.Handler
 	if backend == "geolocation" {
-		handler = i.geobackend
+		handler = geoHandler(i.geolookup)
 	} else {
-		handler = i.backends(backend)
+		handler = i.getBackend(backend)
 	}
 
 	// TODO: Is there a better way to get an *http.Response from an http.Handler?


### PR DESCRIPTION
This is a slight change in options and the way backends and loggers are implemented. Instead of backends being a single function that takes a name and returns a handler, callers can specify `WithBackend("name", handler)` to explicitly register a backend by name.

Callers can also use `WithDefaultBackend` to get something like the original implementation, where the default backend is a function that takes a name and returns a handler.

This same idea is carried over to loggers, with named loggers via `WithLogger` and default logger via `WithDefaultLogger`. The default logger, if not overridden, prints out the message with the log name prefixed.

Because the name `Logger` is now taken by the logging API, I reworded the original log option to `WithVerbosity` and added a `-v` flag to the binary to set the verbosity level.

closes #20 and #19 