### PR TITLE
Implement dictionary API, including CLI support

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -15,6 +15,13 @@ const (
 	XqdErrHttpIncomplete  int32 = 9
 )
 
+// HandleInvalid is returned to guests when they attempt to obtain a handle that doesn't exist. For
+// instance, opening a dictionary that is not registered
+// Note that this is dictinct from XqdErrInvalidHandle, which is returned when callers attempt to
+// *use* an otherwise invalid handle, such as attempting to send a request whose handle has not
+// been created.
+const HandleInvalid = 4294967295 - 1
+
 const (
 	Http09 int32 = 0
 	Http10 int32 = 1

--- a/dictionary.go
+++ b/dictionary.go
@@ -1,0 +1,34 @@
+package fastlike
+
+type LookupFunc func(key string) string
+
+func (i *Instance) addDictionary(name string, fn LookupFunc) {
+	if i.dictionaries == nil {
+		i.dictionaries = []dictionary{}
+	}
+
+	i.dictionaries = append(i.dictionaries, dictionary{name, fn})
+}
+
+func (i *Instance) getDictionaryHandle(name string) int {
+	for j, d := range i.dictionaries {
+		if d.name == name {
+			return j
+		}
+	}
+
+	return HandleInvalid
+}
+
+func (i *Instance) getDictionary(handle int) LookupFunc {
+	if handle > len(i.dictionaries)-1 {
+		return nil
+	}
+
+	return i.dictionaries[handle].get
+}
+
+type dictionary struct {
+	name string
+	get  LookupFunc
+}

--- a/instance.go
+++ b/instance.go
@@ -43,6 +43,9 @@ type Instance struct {
 	loggers       []logger
 	defaultLogger func(name string) io.Writer
 
+	// dictionaries are used to look up string values using string keys
+	dictionaries []dictionary
+
 	// geolookup is a function that accepts a net.IP and returns a Geo
 	geolookup func(net.IP) Geo
 
@@ -69,6 +72,7 @@ func NewInstance(wasmbytes []byte, opts ...Option) *Instance {
 
 	i.backends = map[string]http.Handler{}
 	i.loggers = []logger{}
+	i.dictionaries = []dictionary{}
 
 	// By default, any subrequests will return a 502
 	i.defaultBackend = defaultBackend

--- a/options.go
+++ b/options.go
@@ -48,6 +48,13 @@ func WithDefaultLogger(fn func(name string) io.Writer) Option {
 	}
 }
 
+// WithDictionary registers a new dictionary with a corresponding lookup function
+func WithDictionary(name string, fn LookupFunc) Option {
+	return func(i *Instance) {
+		i.addDictionary(name, fn)
+	}
+}
+
 // WithSecureFunc is an Option that determines if a request should be considered "secure" or not.
 // If it returns true, the request url has the "https" scheme and the "fastly-ssl" header set when
 // going into the wasm program.

--- a/testdata/example-dictionary.json
+++ b/testdata/example-dictionary.json
@@ -1,0 +1,3 @@
+{
+  "greeting": "hello from fastlike"
+}

--- a/testdata/src/main.rs
+++ b/testdata/src/main.rs
@@ -92,6 +92,16 @@ fn main(mut req: Request<Body>) -> Result<impl ResponseExt, Error> {
             Ok(Response::builder().status(StatusCode::NO_CONTENT).body(Body::new())?)
         },
 
+        (&Method::GET, path) if path.starts_with("/dictionary") => {
+            // open the dictionary and get the key specified in the path
+            let parts: Vec<&str> = path[1..].split("/").collect();
+            let (name, key) = (parts[1], parts[2]);
+            use fastly::dictionary::Dictionary;
+            let dict = Dictionary::open(name);
+            let value = dict.get(key).unwrap();
+            Ok(Response::builder().status(StatusCode::OK).body(Body::from(value))?)
+        },
+
         // This one is used for example purposes, not tests
         (&Method::GET, path) if path.starts_with("/testdata") => {
             Ok(req.send(BACKEND)?)

--- a/wasmcontext.go
+++ b/wasmcontext.go
@@ -113,6 +113,10 @@ func (i *Instance) link(linker *wasmtime.Linker) {
 	// xqd_log.go
 	linker.DefineFunc("fastly_log", "endpoint_get", i.xqd_log_endpoint_get)
 	linker.DefineFunc("fastly_log", "write", i.xqd_log_write)
+
+	// xqd_dictionary.go
+	linker.DefineFunc("fastly_dictionary", "open", i.xqd_dictionary_open)
+	linker.DefineFunc("fastly_dictionary", "get", i.xqd_dictionary_get)
 }
 
 // linklegacy links in the abi methods using the legacy method names

--- a/xqd_dictionary.go
+++ b/xqd_dictionary.go
@@ -1,0 +1,48 @@
+package fastlike
+
+func (i *Instance) xqd_dictionary_open(name_addr int32, name_size int32, addr int32) int32 {
+	var buf = make([]byte, name_size)
+	var _, err = i.memory.ReadAt(buf, int64(name_addr))
+	if err != nil {
+		return XqdError
+	}
+
+	var name = string(buf)
+
+	i.abilog.Printf("dictionary_open: name=%s\n", name)
+
+	// Write an int32 "handle" to the configured dictionary to `addr`
+	handle := i.getDictionaryHandle(name)
+
+	i.memory.PutUint32(uint32(handle), int64(addr))
+
+	return XqdStatusOK
+}
+
+func (i *Instance) xqd_dictionary_get(handle int32, key_addr int32, key_size int32, addr int32, size int32, nwritten_out int32) int32 {
+
+	var lookup = i.getDictionary(int(handle))
+	if lookup == nil {
+		return XqdErrInvalidHandle
+	}
+
+	var buf = make([]byte, key_size)
+	var _, err = i.memory.ReadAt(buf, int64(key_addr))
+	if err != nil {
+		return XqdError
+	}
+
+	var key = string(buf)
+
+	i.abilog.Printf("dictionary_get: handle=%d key=%s", handle, key)
+
+	var value = lookup(key)
+
+	nwritten, err := i.memory.WriteAt([]byte(value), int64(addr))
+	if err != nil {
+		return XqdError
+	}
+
+	i.memory.PutUint32(uint32(nwritten), int64(nwritten_out))
+	return XqdStatusOK
+}


### PR DESCRIPTION
There's a new CLI flag, `-d` (or `-dictionary`) that takes `name=file.json`, where `file.json` contains a JSON document with string values. You can use it like so:

`go run ./cmd/fastlike -backend localhost:2000 -wasm testdata/target/wasm32-wasi/debug/example.wasm -d example=testdata/example-dictionary.json`

And then `curl localhost:5000/dictionary/example/greeting` should print `Hello from fastlike`.

Note that there's no "default dictionary" option like there is for loggers and backends, but I could consider adding it. It would be a single function that takes a name and key and returns a value.