### PR TITLE
Update deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module fastlike.dev
 
 go 1.15
 
-require github.com/bytecodealliance/wasmtime-go v0.21.0
+require github.com/bytecodealliance/wasmtime-go v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/bytecodealliance/wasmtime-go v0.21.0 h1:8C6fNmpfzF6QQ9h0PCvGaYORhtgMvANCumafDPDmBSU=
-github.com/bytecodealliance/wasmtime-go v0.21.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
+github.com/bytecodealliance/wasmtime-go v0.26.1 h1:xDzNH+Iq5o4N27pmsvB8cY35feN3H4d3bS7RjddBPWQ=
+github.com/bytecodealliance/wasmtime-go v0.26.1/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=

--- a/specs/testdata/rust/Cargo.lock
+++ b/specs/testdata/rust/Cargo.lock
@@ -2,15 +2,15 @@
 # It is not intended for manual editing.
 [[package]]
 name = "anyhow"
-version = "1.0.28"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
@@ -20,21 +20,21 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
-name = "cfg-if"
-version = "0.1.10"
+name = "bytes"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "chrono"
-version = "0.4.11"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -51,29 +51,31 @@ dependencies = [
 
 [[package]]
 name = "fastly"
-version = "0.5.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e9d2a7ef97cb0d4619458538228ff22f527df4e8c97ba69b7a9a7375efa726"
+checksum = "b902d81a7be2a0bfc504bf82e5f28db32da16c390e4a40660b66fa9ba0d21012"
 dependencies = [
  "anyhow",
- "bytes",
+ "bytes 0.5.6",
  "chrono",
  "fastly-macros",
  "fastly-shared",
  "fastly-sys",
  "http",
  "lazy_static",
- "log",
+ "mime",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "thiserror",
+ "url",
 ]
 
 [[package]]
 name = "fastly-macros"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9984ad9326e0e677e00ab5a996942ad6eacc9b085877bc078bad9b3119fd808"
+checksum = "f46f7f93d61e27761c23c1b613b130d3e37803df0d472ac70d899a6e0bf98480"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -82,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-shared"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0589ab13a2e0a54eba06e4b281b6611d10eb26fc9ab2fc59d266a6f03506f2"
+checksum = "c37497a50d8f8f4d8adbfeadc203606c5b3127d3a006058a4303912e0fc86cd2"
 dependencies = [
  "bitflags",
  "http",
@@ -93,35 +95,56 @@ dependencies = [
 
 [[package]]
 name = "fastly-sys"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8bb88322ba43fe939b3b18fc3e8b1387a0df67fb55c3cade44b1c4c6321589"
+checksum = "1a62f76ee7ad35f28e2e2b84a36dd6f1781dd61a139151f3550bd539714b22f0"
 dependencies = [
  "fastly-shared",
 ]
 
 [[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
 
 [[package]]
-name = "itoa"
-version = "0.4.5"
+name = "idna"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lazy_static"
@@ -130,19 +153,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "log"
-version = "0.4.8"
+name = "matches"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-dependencies = [
- "cfg-if",
-]
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -150,51 +176,57 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.10"
+name = "percent-encoding"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.106"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -203,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.52"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -213,10 +245,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.17"
+name = "serde_urlencoded"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -225,18 +269,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -244,7 +288,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.0"
+name = "tinyvec"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]

--- a/specs/testdata/rust/Cargo.toml
+++ b/specs/testdata/rust/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 debug = true
 
 [dependencies]
-fastly = "^0.5.0"
+fastly = "^0.7.0"
 serde_json = "1.0"

--- a/specs/testdata/rust/src/main.rs
+++ b/specs/testdata/rust/src/main.rs
@@ -1,26 +1,25 @@
-use fastly::http::{HeaderValue, Method, StatusCode};
-use fastly::request::downstream_client_ip_addr;
+use fastly::{Request, Response, Body, Error};
+use fastly::http::{Method, StatusCode};
+use fastly::experimental::uap_parse;
 use fastly::geo::geo_lookup;
-use fastly::{Body, Error, Request, RequestExt, Response, ResponseExt};
-use fastly::uap_parse;
 use serde_json;
 
 const BACKEND: &str = "backend";
 
 #[fastly::main]
-fn main(mut req: Request<Body>) -> Result<impl ResponseExt, Error> {
-    match (req.method(), req.uri().path()) {
-        (&Method::GET, "/simple-response") => Ok(Response::builder()
-            .status(StatusCode::OK)
-            .body(Body::from("Hello, world!"))?
+fn main(mut req: Request) -> Result<Response, Error> {
+    match (req.get_method(), req.get_url().path()) {
+        (&Method::GET, "/simple-response") => Ok(Response::new()
+            .with_status(200)
+            .with_body("Hello, world!")
         ),
 
-        (&Method::GET, "/no-body") => Ok(Response::builder()
-            .status(StatusCode::NO_CONTENT)
-            .body(Body::new())?),
+        (&Method::GET, "/no-body") => Ok(Response::new()
+            .with_status(StatusCode::NO_CONTENT)
+        ),
 
         (&Method::GET, "/user-agent") => {
-            let ua = req.headers().get("user-agent");
+            let ua = req.get_header("user-agent");
             let result = match ua {
                 Some(inner) => {
                     uap_parse(inner.to_str()?)
@@ -38,23 +37,20 @@ fn main(mut req: Request<Body>) -> Result<impl ResponseExt, Error> {
                 },
                 Err(_) => { "error".to_string() },
             };
-            Ok(Response::builder()
-               .status(StatusCode::OK)
-               .body(Body::from(s))?)
+            Ok(Response::new()
+               .with_status(200)
+               .with_body(s)
+            )
         },
 
         (&Method::GET, "/append-header") => {
-            req.headers_mut().insert("test-header", HeaderValue::from_static("test-value"));
+            req.set_header("test-header", "test-value");
             Ok(req.send(BACKEND)?)
         },
 
         (&Method::GET, "/append-body") => {
-            let other = Body::from("appended");
-            let rw = Response::new(Body::from("original\n"));
-            let (mut parts, mut body) = rw.into_parts();
-            body.append(other);
-            parts.status = StatusCode::OK;
-            let rv = Response::from_parts(parts, body);
+            let mut rv = Response::from_body("original\n");
+            rv.append_body(Body::from("appended"));
             Ok(rv)
         },
 
@@ -67,20 +63,18 @@ fn main(mut req: Request<Body>) -> Result<impl ResponseExt, Error> {
         },
 
         (&Method::GET, "/geo") => {
-            let ip = downstream_client_ip_addr();
+            let ip = req.get_client_ip_addr();
             if ip.is_none() {
-                return Ok(Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR).body(Body::new())?);
+                return Ok(Response::from_status(500));
             }
             let geodata = geo_lookup(ip.unwrap()).unwrap();
-            Ok(Response::builder()
-                .status(StatusCode::OK)
-                .body(
-                    Body::from(
-                        serde_json::json!({
-                            "as_name": geodata.as_name(),
-                        }).to_string()
-                    )
-                )?
+            Ok(Response::new()
+                .with_status(200)
+                .with_body(
+                    serde_json::json!({
+                        "as_name": geodata.as_name(),
+                    }).to_string()
+                )
             )
         },
 
@@ -89,22 +83,22 @@ fn main(mut req: Request<Body>) -> Result<impl ResponseExt, Error> {
             use fastly::log::Endpoint;
             let mut endpoint = Endpoint::from_name("default");
             writeln!(endpoint, "Hello from fastlike!").unwrap();
-            Ok(Response::builder().status(StatusCode::NO_CONTENT).body(Body::new())?)
+            Ok(Response::from_status(StatusCode::NO_CONTENT))
         },
 
         (&Method::GET, path) if path.starts_with("/dictionary") => {
             // open the dictionary and get the key specified in the path
             let parts: Vec<&str> = path[1..].split("/").collect();
             let (name, key) = (parts[1], parts[2]);
-            use fastly::dictionary::Dictionary;
+            use fastly::Dictionary;
             let dict = Dictionary::open(name);
             let value = dict.get(key).unwrap();
-            Ok(Response::builder().status(StatusCode::OK).body(Body::from(value))?)
+            Ok(Response::new().with_status(200).with_body(value))
         },
 
-        _ => Ok(Response::builder()
-            .status(StatusCode::NOT_FOUND)
-            .body(Body::from("The page you requested could not be found"))?
+        _ => Ok(Response::new()
+            .with_status(404)
+            .with_body("The page you requested could not be found")
         ),
     }
 }


### PR DESCRIPTION
This patch updates wasmtime-go and the fastly crate to the latest published versions. Updating the fastly crate involved more significant changes.