### PR TITLE
Add request::close() and response::close()

### DIFF
--- a/wasmcontext.go
+++ b/wasmcontext.go
@@ -90,6 +90,7 @@ func (i *Instance) link(linker *wasmtime.Linker) {
 	// The Go http implementation doesn't make it easy to get at the original headers in order, so
 	// we just use the same sorted order
 	linker.DefineFunc("fastly_http_req", "original_header_names_get", i.xqd_req_header_names_get)
+	linker.DefineFunc("fastly_http_req", "close", i.xqd_req_close)
 
 	// xqd_response.go
 	linker.DefineFunc("fastly_http_resp", "send_downstream", i.xqd_resp_send_downstream)
@@ -102,6 +103,7 @@ func (i *Instance) link(linker *wasmtime.Linker) {
 	linker.DefineFunc("fastly_http_resp", "header_remove", i.xqd_resp_header_remove)
 	linker.DefineFunc("fastly_http_resp", "header_values_get", i.xqd_resp_header_values_get)
 	linker.DefineFunc("fastly_http_resp", "header_values_set", i.xqd_resp_header_values_set)
+	linker.DefineFunc("fastly_http_resp", "close", i.xqd_resp_close)
 
 	// xqd_body.go
 	linker.DefineFunc("fastly_http_body", "new", i.xqd_body_new)
@@ -171,6 +173,7 @@ func (i *Instance) linklegacy(linker *wasmtime.Linker) {
 	// The Go http implementation doesn't make it easy to get at the original headers in order, so
 	// we just use the same sorted order
 	linker.DefineFunc("env", "xqd_req_original_header_names_get", i.xqd_req_header_names_get)
+	linker.DefineFunc("env", "xqd_req_close", i.xqd_req_close)
 
 	// xqd_response.go
 	linker.DefineFunc("env", "xqd_resp_new", i.xqd_resp_new)
@@ -182,6 +185,7 @@ func (i *Instance) linklegacy(linker *wasmtime.Linker) {
 	linker.DefineFunc("env", "xqd_resp_header_names_get", i.xqd_resp_header_names_get)
 	linker.DefineFunc("env", "xqd_resp_header_values_get", i.xqd_resp_header_values_get)
 	linker.DefineFunc("env", "xqd_resp_header_values_set", i.xqd_resp_header_values_set)
+	linker.DefineFunc("env", "xqd_resp_close", i.xqd_resp_close)
 
 	// xqd_body.go
 	linker.DefineFunc("env", "xqd_body_new", i.xqd_body_new)

--- a/xqd_request.go
+++ b/xqd_request.go
@@ -373,3 +373,7 @@ func (i *Instance) xqd_req_send(rhandle int32, bhandle int32, backend_addr, back
 
 	return XqdStatusOK
 }
+
+func (i *Instance) xqd_req_close(handle int32) {
+	i.requests.Get(int(handle)).Close = true
+}

--- a/xqd_response.go
+++ b/xqd_response.go
@@ -160,3 +160,7 @@ func (i *Instance) xqd_resp_header_values_set(handle int32, name_addr int32, nam
 
 	return XqdStatusOK
 }
+
+func (i *Instance) xqd_resp_close(handle int32) {
+	i.responses.Get(int(handle)).Close = true
+}


### PR DESCRIPTION
Since we don't reuse handles, there's not much to be done here.

But we still need these functions to be defined.

See https://github.com/fastly/compute-at-edge-abi/pull/6
