### PR TITLE
xqd_*_header_values_set: clear existing values

### DIFF
--- a/xqd_request.go
+++ b/xqd_request.go
@@ -614,6 +614,8 @@ func (i *Instance) xqd_req_header_values_set(handle int32, name_addr int32, name
 		r.Header = http.Header{}
 	}
 
+	r.Header.Del(header)
+
 	for _, v := range values {
 		r.Header.Add(header, string(v))
 	}

--- a/xqd_response.go
+++ b/xqd_response.go
@@ -331,6 +331,8 @@ func (i *Instance) xqd_resp_header_values_set(handle int32, name_addr int32, nam
 		w.Header = http.Header{}
 	}
 
+	w.Header.Del(header)
+
 	for _, v := range values {
 		w.Header.Add(header, string(v))
 	}


### PR DESCRIPTION
These functions don't add new headers, they are meant to replace them, starting from an empty set.